### PR TITLE
Use streams for blobs

### DIFF
--- a/AVAutomation.sln
+++ b/AVAutomation.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31105.61
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33723.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScanUploadedBlobFunction", "ScanUploadedBlobFunction\ScanUploadedBlobFunction.csproj", "{B728FCE2-3717-41AF-A3A7-292081A57848}"
 EndProject
@@ -10,17 +10,27 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B728FCE2-3717-41AF-A3A7-292081A57848}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B728FCE2-3717-41AF-A3A7-292081A57848}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B728FCE2-3717-41AF-A3A7-292081A57848}.Debug|x64.ActiveCfg = Debug|x64
+		{B728FCE2-3717-41AF-A3A7-292081A57848}.Debug|x64.Build.0 = Debug|x64
 		{B728FCE2-3717-41AF-A3A7-292081A57848}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B728FCE2-3717-41AF-A3A7-292081A57848}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B728FCE2-3717-41AF-A3A7-292081A57848}.Release|x64.ActiveCfg = Release|x64
+		{B728FCE2-3717-41AF-A3A7-292081A57848}.Release|x64.Build.0 = Release|x64
 		{AC416AB0-43E3-4CD6-B5F3-B3B503A13056}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AC416AB0-43E3-4CD6-B5F3-B3B503A13056}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC416AB0-43E3-4CD6-B5F3-B3B503A13056}.Debug|x64.ActiveCfg = Debug|x64
+		{AC416AB0-43E3-4CD6-B5F3-B3B503A13056}.Debug|x64.Build.0 = Debug|x64
 		{AC416AB0-43E3-4CD6-B5F3-B3B503A13056}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC416AB0-43E3-4CD6-B5F3-B3B503A13056}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC416AB0-43E3-4CD6-B5F3-B3B503A13056}.Release|x64.ActiveCfg = Release|x64
+		{AC416AB0-43E3-4CD6-B5F3-B3B503A13056}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ScanHttpServer/ScanHttpServer.csproj
+++ b/ScanHttpServer/ScanHttpServer.csproj
@@ -2,16 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Platforms>AnyCPU;x64</Platforms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HttpMultipartParser" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Exceptions" Version="6.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="HttpMultipartParser" Version="8.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ScanUploadedBlobFunction/Properties/launchSettings.json
+++ b/ScanUploadedBlobFunction/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "ScanUploadedBlobFunction": {
+      "commandName": "Project",
+      "commandLineArgs": "verbose"
+    }
+  }
+}

--- a/ScanUploadedBlobFunction/Properties/serviceDependencies.json
+++ b/ScanUploadedBlobFunction/Properties/serviceDependencies.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets"
+    }
+  }
+}

--- a/ScanUploadedBlobFunction/Properties/serviceDependencies.local.json
+++ b/ScanUploadedBlobFunction/Properties/serviceDependencies.local.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets.user"
+    }
+  }
+}

--- a/ScanUploadedBlobFunction/Remediation.cs
+++ b/ScanUploadedBlobFunction/Remediation.cs
@@ -28,12 +28,12 @@ namespace ScanUploadedBlobFunction
                 {
                     string malwareContainerName = Environment.GetEnvironmentVariable("malwareContainerName");
                     MoveBlob(scanResults.fileName, srcContainerName, malwareContainerName, log).GetAwaiter().GetResult();
-                    log.LogInformation("A malicious file was detected. It has been moved from the unscanned container to the quarantine container");
+                    log.LogInformation($"A malicious file {scanResults.fileName} was detected. It has been moved from the unscanned container to the quarantine container");
                 }
 
                 catch (Exception e)
                 {
-                    log.LogError($"A malicious file was detected, but moving it to the quarantine storage container failed. {e.Message}");
+                    log.LogError($"A malicious file {scanResults.fileName} was detected, but moving it to the quarantine storage container failed. {e.Message}");
                 }
             }
 
@@ -43,12 +43,12 @@ namespace ScanUploadedBlobFunction
                 {
                     string cleanContainerName = Environment.GetEnvironmentVariable("cleanContainerName");
                     MoveBlob(scanResults.fileName, srcContainerName, cleanContainerName, log).GetAwaiter().GetResult();
-                    log.LogInformation("The file is clean. It has been moved from the unscanned container to the clean container");
+                    log.LogInformation($"The file {scanResults.fileName} is clean. It has been moved from the unscanned container to the clean container");
                 }
 
                 catch (Exception e)
                 {
-                    log.LogError($"The file is clean, but moving it to the clean storage container failed. {e.Message}");
+                    log.LogError($"The file {scanResults.fileName} is clean, but moving it to the clean storage container failed. {e.Message}");
                 }
             }
         }
@@ -56,7 +56,7 @@ namespace ScanUploadedBlobFunction
         private static async Task MoveBlob(string srcBlobName, string srcContainerName, string destContainerName, ILogger log)
         {
             //Note: if the srcBlob name already exist in the dest container it will be overwritten
-            
+
             var connectionString = Environment.GetEnvironmentVariable("windefenderstorage");
             var srcContainer = new BlobContainerClient(connectionString, srcContainerName);
             var destContainer = new BlobContainerClient(connectionString, destContainerName);
@@ -67,11 +67,11 @@ namespace ScanUploadedBlobFunction
 
             if (await srcBlob.ExistsAsync())
             {
-                log.LogInformation("MoveBlob: Started file copy");
+                log.LogInformation($"MoveBlob: Started file copy - {srcBlobName}");
                 await destBlob.StartCopyFromUriAsync(srcBlob.Uri);
-                log.LogInformation("MoveBlob: Done file copy");
+                log.LogInformation($"MoveBlob: Done file copy - {srcBlobName}");
                 await srcBlob.DeleteAsync();
-                log.LogInformation("MoveBlob: Source file deleted");
+                log.LogInformation($"MoveBlob: Source file deleted - {srcBlobName}");
             }
         }
     }

--- a/ScanUploadedBlobFunction/ScanUploadedBlob.cs
+++ b/ScanUploadedBlobFunction/ScanUploadedBlob.cs
@@ -11,8 +11,8 @@ namespace ScanUploadedBlobFunction
         [FunctionName("ScanUploadedBlob")]
         public static void Run([BlobTrigger("%targetContainerName%/{name}", Connection = "windefenderstorage")] Stream myBlob, string name, ILogger log)
         {
-            log.LogInformation($"C# Blob trigger ScanUploadedBlob function Processed blob Name:{name} Size: {myBlob.Length} Bytes");
-            
+            log.LogInformation($"C# Blob trigger ScanUploadedBlob function Processing blob Name:{name} Size: {myBlob.Length} Bytes");
+
             var scannerHost = Environment.GetEnvironmentVariable("windowsdefender_host");
             var scannerPort = Environment.GetEnvironmentVariable("windowsdefender_port");
 
@@ -23,10 +23,10 @@ namespace ScanUploadedBlobFunction
                 return;
             }
             log.LogInformation($"Scan Results - {scanResults.ToString(", ")}");
-            log.LogInformation("Handalng Scan Results");
+            log.LogInformation($"Handling Scan Results for {name}");
             var action = new Remediation(scanResults, log);
             action.Start();
-            log.LogInformation($"ScanUploadedBlob function done Processing blob Name:{name} Size: {myBlob.Length} Bytes");
+            log.LogInformation($"ScanUploadedBlob function done Processing blob Name: {name} Size: {myBlob.Length} Bytes");
         }
     }
 }

--- a/ScanUploadedBlobFunction/ScanUploadedBlobFunction.csproj
+++ b/ScanUploadedBlobFunction/ScanUploadedBlobFunction.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <Platforms>AnyCPU;x64</Platforms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="HttpMultipartParser" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
+    <PackageReference Include="HttpMultipartParser" Version="8.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.2" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Changed to use streams instead of trying to load the entire contents of the blob into memory/array/httpRequest to allow processing of files >2GB. Also added the blob file name to some of the logging messages.